### PR TITLE
[BE] 게임 이미지 custom 적용

### DIFF
--- a/websocket/src/main/kotlin/com/puzzle/websocket/game/domain/Game.kt
+++ b/websocket/src/main/kotlin/com/puzzle/websocket/game/domain/Game.kt
@@ -142,28 +142,35 @@ data class Game(
             val name = room.roomName
             val roomSize = room.maxPlayers
             val gameType = "BATTLE"
+            val puzzleImage = room.puzzleImage
             val uuid = UUID.randomUUID().toString()
 
-            val game =
-                Game(
-                    gameId = uuid,
-                    gameName = name,
-                    roomSize = roomSize,
-                    gameType = gameType,
-                    sessionToUser = mutableMapOf(),
-                )
+            // PuzzleRoom에서 받은 puzzleImage 값을 Picture에 전달
+            val picture = Picture.create(
+                width = 1000, // 적절한 width 값을 설정하세요.
+                length = 551, // 적절한 length 값을 설정하세요.
+                pieceSize = 40, // 적절한 퍼즐 조각 크기를 설정하세요.
+                imageName = puzzleImage,
+                encodedString = puzzleImage
+            )
+
+            val game = Game(
+                gameId = uuid,
+                gameName = name,
+                roomSize = roomSize,
+                gameType = gameType,
+                sessionToUser = mutableMapOf(),
+                picture = picture // 생성한 Picture 객체를 설정
+            )
 
             if (gameType == "BATTLE") {
                 game.redTeam = room.redPlayers
-
                 game.blueTeam = room.bluePlayers
-                game.picture = Picture.create()
                 game.startTime = Date()
                 println("$name 배틀 방 생성 / id = $uuid")
             } else if (gameType == "COOPERATION") {
                 game.redTeam = room.redPlayers
                 game.blueTeam = room.bluePlayers
-                game.picture = Picture.create()
                 game.startTime = Date()
                 println("$name 협동 방 생성 / id = $uuid")
             }

--- a/websocket/src/main/kotlin/com/puzzle/websocket/game/domain/Picture.kt
+++ b/websocket/src/main/kotlin/com/puzzle/websocket/game/domain/Picture.kt
@@ -45,13 +45,30 @@ data class Picture(
         )
 
     companion object {
-        fun create(): Picture =
-            Picture(
+        // 새로운 이미지 정보를 받아 생성하는 create 메서드 추가
+        fun create(
+            width: Int,
+            length: Int,
+            pieceSize: Int,
+            imageName: String,
+            encodedString: String
+        ): Picture
+            = Picture(
+                name = imageName,
+                width = width,
+                length = length,
+                pieceSize = pieceSize,
+                encodedString = encodedString
+            )
+
+        // 기존의 기본값으로 생성하는 create 메서드 유지
+        fun create(): Picture
+            = Picture(
                 name = "짱구.jpg",
                 width = 1000,
                 length = 551,
                 pieceSize = 40,
-                encodedString = "짱구.jpg",
+                encodedString = "짱구.jpg"
             )
     }
 }


### PR DESCRIPTION
# [FE|BE|ALL] PR 제목
## 이슈번호
#79 

## 변경사항
- PuzzleRoom에 저장되어 있는 image로 퍼즐 만들기

## 테스트
- 테스트 코드 추가여부 O/X
- 테스트 코드가 추가되지 않았다면 그 이유를 적어주세요.

## 리뷰어에게 하고 싶은 말
- 현재 custom 이미지의 크기가 하드 코딩으로 되어있습니다. 그래서 매핑되지 않는 퍼즐이 존재하는데 추후에 수정해야합니다.