### PR TITLE
[BE] 게임 목록 및 대기방에 BATTLE, 대전모드 변경을 위한 response 수정

### DIFF
--- a/backend/src/main/kotlin/com/puzzle/backend/room/dto/response/RoomListResponse.kt
+++ b/backend/src/main/kotlin/com/puzzle/backend/room/dto/response/RoomListResponse.kt
@@ -18,6 +18,8 @@ data class RoomListResponse(
     val nowPlayers: Int,
     val masterImage: String,
     val masterName: String,
+    // 배틀 시간
+    var battleTimer: Int? = null,
     // 생성 시간
     val createdAt: LocalDateTime,
 ) : Serializable {
@@ -37,6 +39,7 @@ data class RoomListResponse(
                 nowPlayers,
                 room.masterImage,
                 room.masterName,
+                room.battleTimer,
                 room.createdAt,
             )
     }

--- a/backend/src/main/kotlin/com/puzzle/backend/room/dto/response/WaitingRoomResponse.kt
+++ b/backend/src/main/kotlin/com/puzzle/backend/room/dto/response/WaitingRoomResponse.kt
@@ -21,6 +21,7 @@ data class WaitingRoomResponse(
     // 현재 참가자 목록
     val bluePlayers: List<PlayerRequest> = listOf(),
     val master: Long,
+    var battleTimer: Int? = null,
     val createdAt: LocalDateTime,
 ) : Serializable {
     companion object {
@@ -39,6 +40,7 @@ data class WaitingRoomResponse(
                 room.redPlayers,
                 room.bluePlayers,
                 room.master,
+                room.battleTimer,
                 room.createdAt,
             )
     }


### PR DESCRIPTION
# [BE] 게임 목록 및 대기방에 BATTLE, 대전모드 변경을 위한 response 수정
## 이슈번호
222
## 변경사항
- WaitingRoomResponse에 battleTimer 추가
- RoomListResponse에 battleTimer 추가

## 테스트
- 테스트 코드 추가여부 O/X
- 테스트 코드가 추가되지 않았다면 그 이유를 적어주세요.

## 리뷰어에게 하고 싶은 말